### PR TITLE
Improve banner database indicator

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ export const formatTime = (seconds) => {
 const INSTRUCTIONS_VERSION = "2";
 
 const RELEASE_NOTES = [
+  "Banner toont nu dames of heren afhankelijk van de gekozen database",
   "Laden van opgeslagen wedstrijd laadt nu ook de juiste video",
   "Verberg en toon knoppen toegevoegd",
   "Fixed frame met scroll optie voor gemarkeerde momenten toegevoegd",
@@ -613,7 +614,7 @@ const handlePlayerReady = (event) => {
             margin: 0,
           }}
         >
-          Video Analyse NL
+          {`Video Analyse NL - ${tableOptions[table]}`}
         </h1>
       </div>
       <div style={{ display: "flex", alignItems: "flex-start", gap: "20px", marginTop: 20 }}>


### PR DESCRIPTION
## Summary
- show whether "dames" or "heren" database is active in the banner
- add note about this change to the release notes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a9910c68832db5974ca41ae2728a