### PR TITLE
Add 'Dames O21' database option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a small React application for annotating YouTube sports videos.
 Features include:
 - Load a YouTube video via URL.
 - Mark moments with keyboard shortcuts or buttons.
-- Choose between the `matches_heren` and `matches` tables (via a dropdown) to store and load annotations.
+- Choose between the `matches_heren`, `matches` and `matches_u21d` tables (via a dropdown) to store and load annotations.
 - Download annotations as JSON.
 
 Create a `.env` file based on `.env.example` and fill in your Supabase credentials. The app reads the URL and API key from the `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` variables at build time.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a small React application for annotating YouTube sports videos.
 Features include:
 - Load a YouTube video via URL.
 - Mark moments with keyboard shortcuts or buttons.
-- Choose between the `matches_heren`, `matches` and `matches_u21d` tables (via a dropdown) to store and load annotations.
+- Choose between the `matches_heren`, `matches`, `matches_u21d` and `matches_u21h` tables (via a dropdown) to store and load annotations.
 - Download annotations as JSON.
 
 Create a `.env` file based on `.env.example` and fill in your Supabase credentials. The app reads the URL and API key from the `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` variables at build time.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ export const formatTime = (seconds) => {
 const INSTRUCTIONS_VERSION = "2";
 
 const RELEASE_NOTES = [
+  "Categorie Dames O21 toegevoegd",
   "Banner toont nu dames of heren afhankelijk van de gekozen database",
   "Laden van opgeslagen wedstrijd laadt nu ook de juiste video",
   "Verberg en toon knoppen toegevoegd",
@@ -172,7 +173,7 @@ const InstructionsModal = ({ onClose, label }) => (
       <h3>3. Wedstrijd opslaan</h3>
       <ol>
         <li>
-          Selecteer rechtsonder <strong>Heren</strong> of <strong>Dames</strong> en vul in het veld “Wedstrijdnaam…” een herkenbare en unieke titel in.
+          Selecteer rechtsonder <strong>Heren</strong>, <strong>Dames</strong> of <strong>Dames O21</strong> en vul in het veld “Wedstrijdnaam…” een herkenbare en unieke titel in.
         </li>
         <li>
           Klik <strong>Opslaan</strong> om de huidige video + gemarkeerde
@@ -180,7 +181,7 @@ const InstructionsModal = ({ onClose, label }) => (
         </li>
         <li>
           Gebruik <strong>Bekijk opgeslagen</strong> om eerder opgeslagen
-          wedstrijden per categorie, heren of dames, te openen. 
+          wedstrijden per categorie &ndash; Heren, Dames of Dames O21 &ndash; te openen.
         </li>
       </ol>
       <h3>4. Tips</h3>
@@ -338,7 +339,8 @@ const App = () => {
 
   const tableOptions = {
     matches_heren: "Heren",
-    matches: "Dames"
+    matches: "Dames",
+    matches_u21d: "Dames O21"
   };
 
   React.useEffect(() => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,10 +9,11 @@ export const formatTime = (seconds) => {
   return `${m}:${s.toString().padStart(2, "0")}`;
 };
 
-const INSTRUCTIONS_VERSION = "2";
+const INSTRUCTIONS_VERSION = "3";
 
 const RELEASE_NOTES = [
   "Categorie Dames O21 toegevoegd",
+  "Categorie Heren O21 toegevoegd",
   "Banner toont nu dames of heren afhankelijk van de gekozen database",
   "Laden van opgeslagen wedstrijd laadt nu ook de juiste video",
   "Verberg en toon knoppen toegevoegd",
@@ -173,7 +174,7 @@ const InstructionsModal = ({ onClose, label }) => (
       <h3>3. Wedstrijd opslaan</h3>
       <ol>
         <li>
-          Selecteer rechtsonder <strong>Heren</strong>, <strong>Dames</strong> of <strong>Dames O21</strong> en vul in het veld “Wedstrijdnaam…” een herkenbare en unieke titel in.
+          Selecteer rechtsonder <strong>Heren</strong>, <strong>Dames</strong>, <strong>Dames O21</strong> of <strong>Heren O21</strong> en vul in het veld “Wedstrijdnaam…” een herkenbare en unieke titel in.
         </li>
         <li>
           Klik <strong>Opslaan</strong> om de huidige video + gemarkeerde
@@ -181,7 +182,7 @@ const InstructionsModal = ({ onClose, label }) => (
         </li>
         <li>
           Gebruik <strong>Bekijk opgeslagen</strong> om eerder opgeslagen
-          wedstrijden per categorie &ndash; Heren, Dames of Dames O21 &ndash; te openen.
+          wedstrijden per categorie &ndash; Heren, Dames, Dames O21 of Heren O21 &ndash; te openen.
         </li>
       </ol>
       <h3>4. Tips</h3>
@@ -340,7 +341,8 @@ const App = () => {
   const tableOptions = {
     matches_heren: "Heren",
     matches: "Dames",
-    matches_u21d: "Dames O21"
+    matches_u21d: "Dames O21",
+    matches_u21h: "Heren O21"
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- add Dames O21 table option
- mention all three tables in the README
- update instructions in the app
- note new release entry

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868104f4f94832d9998cb68e9332a90