### PR TITLE
Fix upsert conflict target

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -474,11 +474,12 @@ const handlePlayerReady = (event) => {
 
   const saveMatch = async () => {
     if (!matchName || !videoId) return;
-    const { error } = await supabase.from(table).upsert({
-      name: matchName,
-      moments,
-      video_id: videoId
-    });
+    const { error } = await supabase
+      .from(table)
+      .upsert(
+        { name: matchName, moments, video_id: videoId },
+        { onConflict: 'name' }
+      );
 
     if (error) {
       console.error("Fout bij opslaan:", error.message);


### PR DESCRIPTION
## Summary
- ensure match saving uses the `name` column for conflict resolution

## Testing
- `npm run build` *(fails: vite not found)*
- `bash ./codex-setup.sh` *(fails: npm ci requires package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_68681ac89ea4832dba025328412aabdc