### PR TITLE
Add analysis playback mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Features include:
 - Mark moments with keyboard shortcuts or buttons.
 - Choose between the `matches_heren`, `matches`, `matches_u21d` and `matches_u21h` tables (via a dropdown) to store and load annotations.
 - Download annotations as JSON.
+- Switch to Analysis View to play clips per category (15 seconds each). Use the
+  space bar to pause/resume and arrow keys to rewind or fast-forward by 5
+  seconds.
 
 Create a `.env` file based on `.env.example` and fill in your Supabase credentials. The app reads the URL and API key from the `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` variables at build time.
  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a small React application for annotating YouTube sports videos.
 
 Features include:
-- Load a YouTube video via URL.
+- Load a YouTube video via URL (supports regular and `/live/` links).
 - Mark moments with keyboard shortcuts or buttons.
 - Choose between the `matches_heren`, `matches`, `matches_u21d` and `matches_u21h` tables (via a dropdown) to store and load annotations.
 - Download annotations as JSON.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -490,7 +490,11 @@ const handlePlayerReady = (event) => {
   };
 
   const getYouTubeVideoId = (url) => {
-    const match = url.match(/[?&]v=([^&]+)/) || url.match(/youtu\.be\/([^?]+)/);
+    const match =
+      url.match(/[?&]v=([^&]+)/) ||
+      url.match(/youtu\.be\/([^?]+)/) ||
+      url.match(/youtube\.com\/live\/([^?]+)/) ||
+      url.match(/youtube\.com\/embed\/([^?]+)/);
     return match ? match[1] : null;
   };
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -386,12 +386,15 @@ const App = () => {
       } else if (key === 'e') {
         markMoment("", true);
       } else if (e.key === 'ArrowLeft') {
+        clearPlayback();
         const t = Math.max(0, player.getCurrentTime() - 5);
         player.seekTo(t, true);
       } else if (e.key === 'ArrowRight') {
+        clearPlayback();
         const t = Math.min(player.getDuration(), player.getCurrentTime() + 5);
         player.seekTo(t, true);
       } else if (e.key === 'ArrowUp') {
+        clearPlayback();
         const rates = player.getAvailablePlaybackRates();
         const current = player.getPlaybackRate();
         const idx = rates.indexOf(current);
@@ -401,6 +404,7 @@ const App = () => {
           setPlaybackRate(newRate);
         }
       } else if (e.key === 'ArrowDown') {
+        clearPlayback();
         const rates = player.getAvailablePlaybackRates();
         const current = player.getPlaybackRate();
         const idx = rates.indexOf(current);
@@ -410,6 +414,7 @@ const App = () => {
           setPlaybackRate(newRate);
         }
       } else if (key === ' ') {
+        clearPlayback();
         const state = player.getPlayerState();
         if (state === 1) {
           player.pauseVideo();
@@ -633,7 +638,7 @@ const handlePlayerReady = (event) => {
         return;
       }
       const start = clips[idx].time;
-      const end = idx < clips.length - 1 ? Math.min(start + 10, clips[idx + 1].time) : start + 10;
+      const end = idx < clips.length - 1 ? Math.min(start + 15, clips[idx + 1].time) : start + 15;
       player.seekTo(start, true);
       player.playVideo();
       idx += 1;


### PR DESCRIPTION
## Summary
- add analysis mode state and playback control
- implement per-category playback buttons
- toggle between markeer and analysis modes
- add a 4th sidebar button for switching modes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7109f6b8832d967f0cd7a9fbc1df