### PR TITLE
Add simple worksheet interface

### DIFF
--- a/public/worksheet.html
+++ b/public/worksheet.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Klank- en letteroefeningen</title>
+  <style>
+    body {
+      font-family: 'Comic Sans MS', 'Comic Neue', cursive, sans-serif;
+      background: #fff;
+      color: #000;
+      padding: 20px;
+      max-width: 800px;
+      margin: auto;
+    }
+    h1 {
+      text-align: center;
+      color: #b400b9;
+    }
+    .exercise {
+      border: 2px solid #000;
+      padding: 15px;
+      margin-bottom: 20px;
+      border-radius: 8px;
+    }
+    .word-input span,
+    .word-input input {
+      display: inline-block;
+      font-size: 32px;
+      margin: 0 2px;
+    }
+    .word-input input {
+      width: 40px;
+      text-align: center;
+      border: 2px solid #b400b9;
+      border-radius: 4px;
+    }
+    .choices {
+      display: flex;
+      gap: 15px;
+      margin-top: 10px;
+    }
+    .choice-btn {
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      border: 3px solid #b400b9;
+      font-size: 32px;
+      cursor: pointer;
+      background: #fff;
+    }
+    .choice-btn.correct {
+      background: #6fd964;
+      color: #000;
+    }
+    .choice-btn.wrong {
+      background: #c59df0;
+      color: #000;
+    }
+    .check-btn {
+      margin-top: 10px;
+      padding: 8px 16px;
+      font-size: 18px;
+      background: #b400b9;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+    img.svg-img {
+      width: 120px;
+      height: 120px;
+      display: block;
+      margin-bottom: 10px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Werkblad</h1>
+  <div id="fillExercises"></div>
+  <div id="chooseExercises"></div>
+
+<script>
+  const fillData = [
+    { img: '<svg class="svg-img" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="none" stroke="black" stroke-width="4" /></svg>', word: 'bal', blanks: [0] },
+    { img: '<svg class="svg-img" viewBox="0 0 100 100"><rect x="20" y="20" width="60" height="60" fill="none" stroke="black" stroke-width="4" /></svg>', word: 'doos', blanks: [0] },
+    { img: '<svg class="svg-img" viewBox="0 0 100 100"><polygon points="50,10 90,90 10,90" fill="none" stroke="black" stroke-width="4" /></svg>', word: 'dak', blanks: [0] }
+  ];
+
+  const chooseData = [
+    { img: '<svg class="svg-img" viewBox="0 0 100 100"><polygon points="50,10 90,90 10,90" fill="none" stroke="black" stroke-width="4" /></svg>', letters: ['d','b','p'], correct: 'd' },
+    { img: '<svg class="svg-img" viewBox="0 0 100 100"><rect x="20" y="20" width="60" height="60" fill="none" stroke="black" stroke-width="4" /></svg>', letters: ['k','d','t'], correct: 'k' },
+    { img: '<svg class="svg-img" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="none" stroke="black" stroke-width="4" /></svg>', letters: ['o','a','e'], correct: 'o' }
+  ];
+
+  function renderFillExercises() {
+    const container = document.getElementById('fillExercises');
+    fillData.forEach((ex, idx) => {
+      const div = document.createElement('div');
+      div.className = 'exercise';
+      div.innerHTML = ex.img;
+      const wordDiv = document.createElement('div');
+      wordDiv.className = 'word-input';
+      [...ex.word].forEach((letter, i) => {
+        if (ex.blanks.includes(i)) {
+          const input = document.createElement('input');
+          input.maxLength = 1;
+          input.dataset.correct = letter;
+          wordDiv.appendChild(input);
+        } else {
+          const span = document.createElement('span');
+          span.textContent = letter;
+          wordDiv.appendChild(span);
+        }
+      });
+      div.appendChild(wordDiv);
+      const check = document.createElement('button');
+      check.textContent = 'controleer';
+      check.className = 'check-btn';
+      check.addEventListener('click', () => {
+        wordDiv.querySelectorAll('input').forEach(inp => {
+          inp.style.background = inp.value.toLowerCase() === inp.dataset.correct ? '#6fd964' : '#c59df0';
+        });
+      });
+      div.appendChild(check);
+      container.appendChild(div);
+    });
+  }
+
+  function renderChooseExercises() {
+    const container = document.getElementById('chooseExercises');
+    chooseData.forEach((ex, idx) => {
+      const div = document.createElement('div');
+      div.className = 'exercise';
+      div.innerHTML = ex.img;
+      const choicesDiv = document.createElement('div');
+      choicesDiv.className = 'choices';
+      ex.letters.forEach(letter => {
+        const btn = document.createElement('button');
+        btn.className = 'choice-btn';
+        btn.textContent = letter;
+        btn.addEventListener('click', () => {
+          btn.classList.remove('correct', 'wrong');
+          if (letter === ex.correct) {
+            btn.classList.add('correct');
+          } else {
+            btn.classList.add('wrong');
+          }
+        });
+        choicesDiv.appendChild(btn);
+      });
+      div.appendChild(choicesDiv);
+      container.appendChild(div);
+    });
+  }
+
+  renderFillExercises();
+  renderChooseExercises();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `worksheet.html` with a child-friendly phonics worksheet
  - fill-in-the-letter exercises
  - choose-the-letter exercises
  - big fonts and purple accents

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b8cc6674832d9d5eeebc5c5e0eb4